### PR TITLE
Minor fix for tests, rename test for tree

### DIFF
--- a/2-0-data-structures-and-algorithms/2-2-2-stack/src/test/java/com/bobocode/cs/StackTest.java
+++ b/2-0-data-structures-and-algorithms/2-2-2-stack/src/test/java/com/bobocode/cs/StackTest.java
@@ -353,6 +353,8 @@ class StackTest {
 
         if (constructor.getParameters().length == 1) {
             return constructor.newInstance(element);
+        } else if (constructor.getParameters().length == 2) {
+            return constructor.newInstance(element, null);
         } else {
             Object node = constructor.newInstance();
             getNodeElementField(node).set(node, element);

--- a/2-0-data-structures-and-algorithms/2-2-3-linked-queue/src/test/java/com/bobocode/cs/LinkedQueueTest.java
+++ b/2-0-data-structures-and-algorithms/2-2-3-linked-queue/src/test/java/com/bobocode/cs/LinkedQueueTest.java
@@ -164,13 +164,19 @@ public class LinkedQueueTest {
     }
 
     @Test
+    @SneakyThrows
     @Order(11)
     void pollMakesQueueEmptyWhenQueueHasSingleElement() {
         addIntElementToQueue(1);
         this.integerQueue.poll();
         boolean isEmpty = isEmptyQueue();
 
+        Object tail = getAccessibleFieldByPredicate(integerQueue, TAIL_FIELD).get(integerQueue);
+        Object head = getAccessibleFieldByPredicate(integerQueue, HEAD_FIELD).get(integerQueue);
+
         assertThat(isEmpty).isEqualTo(true);
+        assertThat(tail).isNull();
+        assertThat(head).isNull();
     }
 
     @Test

--- a/2-0-data-structures-and-algorithms/2-2-6-binary-search-tree/src/test/java/com/bobocode/cs/RecursiveBinarySearchTreeTest.java
+++ b/2-0-data-structures-and-algorithms/2-2-6-binary-search-tree/src/test/java/com/bobocode/cs/RecursiveBinarySearchTreeTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class BinarySearchTreeTest {
+class RecursiveBinarySearchTreeTest {
 
     private static final Predicate<Field> SIZE_FIELD = field -> field.getName().toLowerCase().contains("size")
             || field.getName().toLowerCase().contains("length");


### PR DESCRIPTION
1. Fix test in stack exercise, because it failed when constructor has 2 parameters
2. Changed name of test to `RecursiveBinarySearchTreeTest` to be able to move to it using shortcut
3. Fix linked list test. It was possible to have null in head, but tail wan't null