### PR TITLE
CrazyGenerics add tests for checking public accessor type by new methods

### DIFF
--- a/1-0-java-basics/1-3-1-crazy-generics/src/test/java/com/bobocode/basics/CrazyGenericsTest.java
+++ b/1-0-java-basics/1-3-1-crazy-generics/src/test/java/com/bobocode/basics/CrazyGenericsTest.java
@@ -722,9 +722,16 @@ public class CrazyGenericsTest {
         );
     }
 
+    @Test
+    @Order(58)
+    @DisplayName("Method findMax has public accessor type")
+    void findMaxHasPublicAccessorType() {
+        var findMaxMethod = getMethodByName(CollectionUtil.class, "findMax");
+        assertThat(findMaxMethod).isNotNull();
+    }
 
     @ParameterizedTest
-    @Order(58)
+    @Order(59)
     @MethodSource("findMaxArgs")
     @DisplayName("Method findMax returns the max value based on given comparator")
     @SneakyThrows
@@ -755,7 +762,15 @@ public class CrazyGenericsTest {
     }
 
     @Test
-    @Order(59)
+    @Order(60)
+    @DisplayName("Method findMostRecentlyCreatedEntity has public accessor type")
+    void findMostRecentlyCreatedEntityHasPublicAccessorType() {
+        var findMaxMethod = getMethodByName(CollectionUtil.class, "findMostRecentlyCreatedEntity");
+        assertThat(findMaxMethod).isNotNull();
+    }
+
+    @Test
+    @Order(61)
     @DisplayName("findMostRecentlyCreatedEntity is a generic method that accepts a collection of entities")
     void findMostRecentlyCreatedEntityIsAGenericMethod() {
         var hasDuplicatesMethod = getMethodByName(CollectionUtil.class, "findMostRecentlyCreatedEntity");
@@ -767,7 +782,7 @@ public class CrazyGenericsTest {
     }
 
     @ParameterizedTest
-    @Order(60)
+    @Order(62)
     @MethodSource("findMostRecentlyCreatedEntityArgs")
     @DisplayName("findMostRecentlyCreatedEntity returns the most recently created entity")
     @SneakyThrows
@@ -794,7 +809,7 @@ public class CrazyGenericsTest {
     }
 
     @Test
-    @Order(61)
+    @Order(63)
     @DisplayName("findMostRecentlyCreatedEntity throws exception when collection is empty")
     @SneakyThrows
     void findMostRecentlyCreatedEntityThrowsException() {
@@ -805,7 +820,7 @@ public class CrazyGenericsTest {
     }
 
     @Test
-    @Order(62)
+    @Order(64)
     @DisplayName("Method swap does not declare type parameter")
     void swapMethodDoesNotDeclareTypeParameter() {
         var swapMethod = getMethodByName(CollectionUtil.class, "swap");
@@ -815,7 +830,7 @@ public class CrazyGenericsTest {
     }
 
     @Test
-    @Order(63)
+    @Order(65)
     @DisplayName("Method swap change elements by indexes")
     @SneakyThrows
     void swapChangesElements() {

--- a/1-0-java-basics/1-3-1-crazy-generics/src/test/java/com/bobocode/basics/CrazyGenericsTest.java
+++ b/1-0-java-basics/1-3-1-crazy-generics/src/test/java/com/bobocode/basics/CrazyGenericsTest.java
@@ -724,8 +724,8 @@ public class CrazyGenericsTest {
 
     @Test
     @Order(58)
-    @DisplayName("Method findMax has public accessor type")
-    void findMaxHasPublicAccessorType() {
+    @DisplayName("Method findMax has public access type")
+    void findMaxHasPublicAccessType() {
         var findMaxMethod = getMethodByName(CollectionUtil.class, "findMax");
         assertThat(findMaxMethod).isNotNull();
     }
@@ -763,8 +763,8 @@ public class CrazyGenericsTest {
 
     @Test
     @Order(60)
-    @DisplayName("Method findMostRecentlyCreatedEntity has public accessor type")
-    void findMostRecentlyCreatedEntityHasPublicAccessorType() {
+    @DisplayName("Method findMostRecentlyCreatedEntity has public access type")
+    void findMostRecentlyCreatedEntityHasPublicAccessType() {
         var findMostRecentlyCreatedEntity = getMethodByName(CollectionUtil.class, "findMostRecentlyCreatedEntity");
         assertThat(findMostRecentlyCreatedEntity).isNotNull();
     }

--- a/1-0-java-basics/1-3-1-crazy-generics/src/test/java/com/bobocode/basics/CrazyGenericsTest.java
+++ b/1-0-java-basics/1-3-1-crazy-generics/src/test/java/com/bobocode/basics/CrazyGenericsTest.java
@@ -765,8 +765,8 @@ public class CrazyGenericsTest {
     @Order(60)
     @DisplayName("Method findMostRecentlyCreatedEntity has public accessor type")
     void findMostRecentlyCreatedEntityHasPublicAccessorType() {
-        var findMaxMethod = getMethodByName(CollectionUtil.class, "findMostRecentlyCreatedEntity");
-        assertThat(findMaxMethod).isNotNull();
+        var findMostRecentlyCreatedEntity = getMethodByName(CollectionUtil.class, "findMostRecentlyCreatedEntity");
+        assertThat(findMostRecentlyCreatedEntity).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
In CrazyGenerics exercise we need to create two methods findMax and findMostRecentlyCreatedEntity. 
Even with correct implementation, the existing tests fail when the access type is not public but the current description doesn't mention this. 
Let's add new test for pointing on the issue 
