### PR TITLE
Update CrazyGenericsTest#hasDuplicatesArgs (#169)

### DIFF
--- a/1-0-java-basics/1-3-1-crazy-generics/src/test/java/com/bobocode/basics/CrazyGenericsTest.java
+++ b/1-0-java-basics/1-3-1-crazy-generics/src/test/java/com/bobocode/basics/CrazyGenericsTest.java
@@ -716,7 +716,7 @@ public class CrazyGenericsTest {
         var duplicateEntity2 = new TestEntity(duplicateId);
 
         return Stream.of(
-                arguments(List.of(uniqueEntity, duplicateEntity1), uniqueEntity, false),
+                arguments(List.of(uniqueEntity, duplicateEntity1, duplicateEntity2), uniqueEntity, false),
                 arguments(List.of(uniqueEntity, duplicateEntity1, duplicateEntity2), duplicateEntity1, true),
                 arguments(List.of(duplicateEntity1, duplicateEntity2), duplicateEntity1, true)
         );


### PR DESCRIPTION
Verifies that duplicates are checked only against targetEntity. Other possible duplicated entities are not important and shouldn't affect the result (#169)